### PR TITLE
[fix] fixed redisgears loadmodule path and PythonHomeDir

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ CMD ["--loadmodule", "/usr/lib/redis/modules/redisai.so", \
     "--loadmodule", "/usr/lib/redis/modules/redistimeseries.so", \
     "--loadmodule", "/usr/lib/redis/modules/rejson.so", \
     "--loadmodule", "/usr/lib/redis/modules/rebloom.so", \
-    "--loadmodule", "/usr/lib/redis/modules/redisgears.so", \
-    "PythonHomeDir", "/usr/lib/redis/modules/deps/cpython/"]
+    "--loadmodule", "/opt/redislabs/lib/modules/redisgears.so", \
+    "PythonHomeDir", "/opt/redislabs/lib/modules/python3"]


### PR DESCRIPTION
[fix] fixed redisgears loadmodule path and PythonHomeDir

bellow is a sample of the error solved by this PR

`
1:M 22 May 2019 22:42:09.576 # Module /usr/lib/redis/modules/redisgears.so failed to load: 
/usr/lib/redis/modules/redisgears.so: cannot open shared object file: No such file or directory
1:M 22 May 2019 22:42:09.576 # Can't load module from /usr/lib/redis/modules/redisgears.so: server aborting
`