### PR TITLE
Fixed RedisGears module path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,5 +29,5 @@ CMD ["--loadmodule", "/usr/lib/redis/modules/redisai.so", \
     "--loadmodule", "/usr/lib/redis/modules/redistimeseries.so", \
     "--loadmodule", "/usr/lib/redis/modules/rejson.so", \
     "--loadmodule", "/usr/lib/redis/modules/redisbloom.so", \
-    "--loadmodule", "/opt/redislabs/lib/modules/redisgears.so", \
+    "--loadmodule", "/var/opt/redislabs/lib/modules/redisgears.so", \
     "PythonHomeDir", "/opt/redislabs/lib/modules/python3"]


### PR DESCRIPTION
Currently attempting to run `docker run -p 6379:6379 redislabs/redismod` fails because of incorrect RedisGears module path:
```
# Module /opt/redislabs/lib/modules/redisgears.so failed to load: /opt/redislabs/lib/modules/redisgears.so: cannot open shared object file: No such file or directory
# Can't load module from /opt/redislabs/lib/modules/redisgears.so: server aborting
```
This commit updates the module path according to https://github.com/RedisGears/RedisGears/blob/master/Dockerfile#L66