### PR TITLE
Updated Dockerfile and Dockerfile.edge to copy RedisAI backends

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends ${REDISGRAPH_DEPS};
 
-COPY --from=redisai ${LD_LIBRARY_PATH}/*.so* ${LD_LIBRARY_PATH}/
+COPY --from=redisai ${LD_LIBRARY_PATH}/redisai.so ${LD_LIBRARY_PATH}/
+COPY --from=redisai ${LD_LIBRARY_PATH}/backends ${LD_LIBRARY_PATH}/backends
 COPY --from=redisearch ${LD_LIBRARY_PATH}/redisearch.so ${LD_LIBRARY_PATH}/
 COPY --from=redisgraph ${LD_LIBRARY_PATH}/redisgraph.so ${LD_LIBRARY_PATH}/
 COPY --from=redistimeseries ${LD_LIBRARY_PATH}/*.so ${LD_LIBRARY_PATH}/

--- a/Dockerfile.edge
+++ b/Dockerfile.edge
@@ -14,7 +14,8 @@ RUN set -ex; \
     apt-get update; \
     apt-get install -y --no-install-recommends ${REDISGRAPH_DEPS};
 
-COPY --from=redisai ${LD_LIBRARY_PATH}/*.so* ${LD_LIBRARY_PATH}/
+COPY --from=redisai ${LD_LIBRARY_PATH}/redisai.so ${LD_LIBRARY_PATH}/
+COPY --from=redisai ${LD_LIBRARY_PATH}/backends ${LD_LIBRARY_PATH}/backends
 COPY --from=redisearch ${LD_LIBRARY_PATH}/redisearch.so ${LD_LIBRARY_PATH}/
 COPY --from=redisgraph ${LD_LIBRARY_PATH}/redisgraph.so ${LD_LIBRARY_PATH}/
 COPY --from=redistimeseries ${LD_LIBRARY_PATH}/*.so ${LD_LIBRARY_PATH}/


### PR DESCRIPTION
The backends for RedisAI (ONNX, TF, TFLITE, and TORCH) were not being copied to the resultant image. This PR fixes that.